### PR TITLE
Remove `require('sys')`

### DIFF
--- a/bin/html.js
+++ b/bin/html.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-var sys = require("sys")
 var html = require("../lib/html")
 var fs = require('fs')
 


### PR DESCRIPTION
It was not being used (WTF) and in modern versions of Node it resulted in the following warning:

> The `sys` module is now called `util`. It should have a similar interface.

Please publish a new version after merging this. Thanks!
