### PR TITLE
Upgrade to glob@5.0.15 due to security reasons

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/maxogden/commonjs-html-prettyprinter",
   "dependencies": {
     "concat-stream": "^1.4.7",
-    "glob": "^3.1.13"
+    "glob": "^5.0.15"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This should prevent https://snyk.io/vuln/npm:minimatch:20160620.

------

Closes https://github.com/maxogden/commonjs-html-prettyprinter/pull/11. I made another PR because the original one was from my personal fork and now we decided we need an `@apiaryio` fork which we can install from until this fix gets to upstream.