### PR TITLE
Remove glob from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   },
   "homepage": "https://github.com/maxogden/commonjs-html-prettyprinter",
   "dependencies": {
-    "concat-stream": "^1.4.7",
-    "glob": "^3.1.13"
+    "concat-stream": "^1.4.7"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
fixes #13 
closes #12

`glob` is listed in package.json, but is [not being used](https://github.com/maxogden/commonjs-html-prettyprinter/issues/13#issuecomment-238333116). There is a security vulnerability with the listed version of `glob`.

This Pull Request removes glob from package.json.
