### PR TITLE
Don't add extra lines around the <head> and <body> tags

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -36,8 +36,10 @@
     });
 */
 
+//
+// Wrapper function to invoke all the necessary constructors and deal with the output.
+//
 function style_html(html_source, options) {
-//Wrapper function to invoke all the necessary constructors and deal with the output.
 
   var multi_parser,
       indent_size,
@@ -69,7 +71,6 @@ function style_html(html_source, options) {
     this.Utils = { //Uilities made available to the various functions
       whitespace: "\n\r\t ".split(''),
       single_token: 'br,input,link,meta,!doctype,basefont,base,area,hr,wbr,param,img,isindex,?xml,embed,?php,?,?='.split(','), //all the single tags for HTML
-      extra_liners: 'head,body,/html'.split(','), //for tags that need a line of whitespace before them
       in_array: function (what, arr) {
         for (var i=0; i<arr.length; i++) {
           if (what === arr[i]) {
@@ -290,9 +291,6 @@ function style_html(html_source, options) {
         else { //otherwise it's a start-tag
           this.record_tag(tag_check); //push it on the tag stack
           this.tag_type = 'START';
-        }
-        if (this.Utils.in_array(tag_check, this.Utils.extra_liners)) { //check if this double needs an extra line
-          this.print_newline(true, this.output);
         }
       }
       return content.join(''); //returns fully formatted tag


### PR DESCRIPTION
Most people are probably not looking to add extra spaces around the `<head>` and `<body>` tags.

It was doing this:

```html
<html>

  <head>
  </head>

  <body>
  </body>

</html>
```

Perhaps it could be an option, but certainly not default behavior.